### PR TITLE
Fixed thread lock issue

### DIFF
--- a/resources/META-INF/MANIFEST.MF
+++ b/resources/META-INF/MANIFEST.MF
@@ -1,0 +1,66 @@
+Manifest-Version: 1.0
+Main-Class: com.ss.editor.Launcher
+Class-Path: rlib-6.1.2.jar annotations-15.0.jar rlib-6.1.2-sources.jar g
+ roovy-all-2.5.0-alpha-1.jar jme3-spaceshift-extension-1.0.1.jar jme3-sp
+ aceshift-extension-1.0.1-sources.jar guava-18.0.jar xbuf-0.9.1.jar slf4
+ j-api-1.7.25.jar jme3_xbuf_rt-0.9.1.jar protobuf-java-3.0.0.jar slf4j-s
+ imple-1.7.25.jar jme3_physicsloader-0.5.jar jme3_xbuf_loader-0.9.1.jar 
+ protobuf-java-util-3.0.0.jar lemur-1.9.1.jar sim-fx-1.0.4.jar iso-surfa
+ ce.1.0.0.jar lemur-1.9.1-sources.jar sim-fx-1.0.4-sources.jar iso-surfa
+ ce-sources.1.0.0.jar log4j-1.2.6.jar xalan-2.7.0.jar logkit-1.0.1.jar b
+ atik-css-1.8.jar batik-dom-1.8.jar batik-ext-1.8.jar batik-gvt-1.8.jar 
+ batik-xml-1.8.jar batik-anim-1.8.jar batik-util-1.8.jar javafxsvg-1.2.1
+ .jar xml-apis-1.3.04.jar batik-bridge-1.8.jar batik-parser-1.8.jar bati
+ k-script-1.8.jar batik-svggen-1.8.jar commons-io-1.3.1.jar batik-svg-do
+ m-1.8.jar batik-awt-util-1.8.jar xalan-2.7.0-sources.jar xml-apis-ext-1
+ .3.04.jar batik-transcoder-1.8.jar logkit-1.0.1-sources.jar batik-css-1
+ .8-sources.jar batik-dom-1.8-sources.jar batik-ext-1.8-sources.jar bati
+ k-gvt-1.8-sources.jar batik-xml-1.8-sources.jar commons-logging-1.0.4.j
+ ar avalon-framework-4.1.3.jar batik-anim-1.8-sources.jar batik-util-1.8
+ -sources.jar xml-apis-1.3.04-source.jar javafxsvg-1.2.1-sources.jar xml
+ graphics-commons-2.1.jar batik-bridge-1.8-sources.jar batik-parser-1.8-
+ sources.jar batik-script-1.8-sources.jar batik-svggen-1.8-sources.jar c
+ ommons-io-1.3.1-sources.jar batik-svg-dom-1.8-sources.jar batik-awt-uti
+ l-1.8-sources.jar batik-transcoder-1.8-sources.jar commons-logging-1.0.
+ 4-sources.jar xmlgraphics-commons-2.1-sources.jar httpcore-4.4.4.jar ht
+ tpclient-4.5.2.jar commons-codec-1.9.jar commons-logging-1.2.jar toneg0
+ d.emitter-2.2.3.jar toneg0d.emitter-2.2.3-sources.jar guava-18.0.jar xb
+ uf-0.9.1.jar slf4j-api-1.7.25.jar jme3_xbuf_rt-0.9.1.jar protobuf-java-
+ 3.0.0.jar slf4j-simple-1.7.25.jar jme3_physicsloader-0.5.jar jme3_xbuf_
+ loader-0.9.1.jar protobuf-java-util-3.0.0.jar toneg0d.emitter-2.2.3.jar
+  toneg0d.emitter-2.2.3-sources.jar core-0.27.jar dense64-0.27.jar dense
+ C64-0.27.jar eventbus-1.4.jar j-ogg-all-1.0.0.jar jglfont-core-1.4.jar 
+ jinput-2.0.5.jar jinput-platform-2.0.5-natives-linux.jar jme3-bullet-3.
+ 2.0.jar jme3-bullet-native-3.2.0.jar jme3-core-3.2.0.jar jme3-desktop-3
+ .2.0.jar jme3-effects-3.2.0.jar jme3-jogg-3.2.0.jar jme3-lwjgl3-3.2.0.j
+ ar jme3-plugins-3.2.0.jar jme3-terrain-3.2.0.jar jsr305-2.0.2.jar jutil
+ s-1.0.0.jar lwjgl.jar lwjgl-glfw-3.2.3.jar lwjgl-glfw-natives-linux.jar
+  lwjgl-jemalloc.jar lwjgl-jemalloc-natives-linux.jar lwjgl-natives-linu
+ x.jar lwjgl-openal.jar lwjgl-openal-natives-linux.jar lwjgl-opencl.jar 
+ lwjgl-opengl.jar lwjgl-opengl-natives-linux.jar lwjgl-stb.jar lwjgl-stb
+ -natives-linux.jar retrace.jar simple-0.27.jar stack-alloc.jar vecmath-
+ 1.3.1.jar xpp3-1.1.4c.jar gson-2.6.2.jar jme-jfx-1.5.2.jar rlib-fx-4.1.
+ 2.jar common-io-3.3.2.jar common-lang-3.3.2.jar commons-lang3-3.4.jar i
+ mageio-hdr-3.3.2.jar common-image-3.3.2.jar imageio-core-3.3.2.jar imag
+ eio-tiff-3.3.2.jar imageio-batik-3.3.2.jar jme-jfx-1.5.2-sources.jar ri
+ chtextfx-fat-0.7-M5.jar rlib-fx-4.1.2-sources.jar imageio-metadata-3.3.
+ 2.jar commons-lang3-3.4-javadoc.jar richtextfx-0.7-M5-sources.jar lwjgl
+ .jar retrace.jar core-0.27.jar lwjgl-stb.jar jme3-lwjgl.jar simple-0.27
+ .jar stack-alloc.jar xpp3-1.1.4c.jar dense64-0.27.jar eventbus-1.4.jar 
+ jinput-2.0.5.jar jsr305-2.0.2.jar jutils-1.0.0.jar lwjgl-openal.jar lwj
+ gl-opencl.jar lwjgl-opengl.jar denseC64-0.27.jar lwjgl-sources.jar vecm
+ ath-1.3.1.jar lwjgl-jemalloc.jar j-ogg-all-1.0.0.jar jme3-core-3.2.0.ja
+ r jme3-jogg-3.2.0.jar jglfont-core-1.4.jar lwjgl-glfw-3.2.3.jar jme3-bu
+ llet-3.2.0.jar jme3-lwjgl3-3.2.0.jar lwjgl-stb-sources.jar jme3-desktop
+ -3.2.0.jar jme3-effects-3.2.0.jar jme3-plugins-3.2.0.jar jme3-terrain-3
+ .2.0.jar lwjgl-glfw-sources.jar lwjgl-natives-linux.jar lwjgl-openal-so
+ urces.jar lwjgl-opencl-sources.jar lwjgl-opengl-sources.jar lwjgl-jemal
+ loc-sources.jar jme3-core-3.2.0-sources.jar jme3-jogg-3.2.0-sources.jar
+  lwjgl-stb-natives-linux.jar jme3-bullet-native-3.2.0.jar lwjgl-glfw-na
+ tives-linux.jar jme3-bullet-3.2.0-sources.jar jme3-desktop-3.2.0-source
+ s.jar jme3-effects-3.2.0-sources.jar jme3-plugins-3.2.0-sources.jar jme
+ 3-terrain-3.2.0-sources.jar lwjgl-openal-natives-linux.jar lwjgl-opengl
+ -natives-linux.jar lwjgl-jemalloc-natives-linux.jar lwjgl-platform-nati
+ ves-linux.jar jme3-bullet-native-3.2.0-sources.jar jinput-platform-2.0.
+ 5-natives-linux.jar
+

--- a/src/com/ss/editor/ui/component/editor/FileEditor.java
+++ b/src/com/ss/editor/ui/component/editor/FileEditor.java
@@ -1,9 +1,8 @@
 package com.ss.editor.ui.component.editor;
 
-import com.ss.editor.annotation.FXThread;
-import com.ss.editor.annotation.FromAnyThread;
 import com.ss.editor.state.editor.EditorAppState;
 
+import com.ss.editor.util.EditorStateManager;
 import org.jetbrains.annotations.NotNull;
 
 import java.nio.file.Path;
@@ -30,8 +29,6 @@ public interface FileEditor {
      *
      * @return the page for showing the editor.
      */
-    @NotNull
-    @FXThread
     Parent getPage();
 
     /**
@@ -39,8 +36,6 @@ public interface FileEditor {
      *
      * @return the file name of the current opened file.
      */
-    @NotNull
-    @FXThread
     String getFileName();
 
     /**
@@ -48,8 +43,6 @@ public interface FileEditor {
      *
      * @return the editing file.
      */
-    @NotNull
-    @FXThread
     Path getEditFile();
 
     /**
@@ -57,7 +50,6 @@ public interface FileEditor {
      *
      * @param file the file.
      */
-    @FXThread
     void openFile(@NotNull final Path file);
 
     /**
@@ -65,8 +57,6 @@ public interface FileEditor {
      *
      * @return the dirty property of this editor.
      */
-    @NotNull
-    @FXThread
     BooleanProperty dirtyProperty();
 
     /**
@@ -76,10 +66,10 @@ public interface FileEditor {
      */
     boolean isDirty();
 
-    /**
-     * Save new changes.
-     */
     default void doSave() {
+    }
+
+    default void onSaved() {
     }
 
     /**
@@ -87,8 +77,6 @@ public interface FileEditor {
      *
      * @return the 3D part of this editor.
      */
-    @NotNull
-    @FXThread
     default Array<EditorAppState> getStates() {
         return EMPTY_STATES;
     }
@@ -96,8 +84,7 @@ public interface FileEditor {
     /**
      * Notify that this editor was closed.
      */
-    @FXThread
-    default void notifyClosed() {
+    default void onClosed() {
     }
 
     /**
@@ -106,8 +93,7 @@ public interface FileEditor {
      * @param prevFile the prev file
      * @param newFile  the new file
      */
-    @FXThread
-    default void notifyRenamed(@NotNull final Path prevFile, @NotNull final Path newFile) {
+    default void onRenamed(@NotNull final Path prevFile, @NotNull final Path newFile) {
     }
 
     /**
@@ -116,8 +102,7 @@ public interface FileEditor {
      * @param prevFile the prev file
      * @param newFile  the new file
      */
-    @FXThread
-    default void notifyMoved(@NotNull final Path prevFile, @NotNull final Path newFile) {
+    default void onMoved(@NotNull final Path prevFile, @NotNull final Path newFile) {
     }
 
     /**
@@ -125,22 +110,18 @@ public interface FileEditor {
      *
      * @return the description of this editor.
      */
-    @NotNull
-    @FromAnyThread
     EditorDescription getDescription();
 
     /**
      * Notify that this editor was showed.
      */
-    @FXThread
-    default void notifyShowed() {
+    default void onShown() {
     }
 
     /**
      * Notify that this editor was hided.
      */
-    @FXThread
-    default void notifyHided() {
+    default void onDismissed() {
     }
 
     /**
@@ -150,7 +131,6 @@ public interface FileEditor {
      * @param sceneY the scene y
      * @return true if the point is inside in this editor.
      */
-    @FXThread
     default boolean isInside(double sceneX, double sceneY) {
         return false;
     }

--- a/src/com/ss/editor/ui/controller/model/tree/dialog/terrain/CreateTerrainDialog.java
+++ b/src/com/ss/editor/ui/controller/model/tree/dialog/terrain/CreateTerrainDialog.java
@@ -654,13 +654,13 @@ public class CreateTerrainDialog extends AbstractSimpleEditorDialog {
         super.processOk();
         EditorUtil.incrementLoading();
         EXECUTOR_MANAGER.addBackgroundTask(() -> {
-
-            try {
-                createTerrainInBackground();
-            } catch (final Exception e) {
-                EditorUtil.handleException(LOGGER, this, e);
-            }
-
+                EDITOR.enqueue(() -> {
+                    try {
+                        createTerrainInBackground();
+                    } catch (Exception e) {
+                        EditorUtil.handleException(LOGGER, this, e);
+                    }
+                });
             EXECUTOR_MANAGER.addFXTask(EditorUtil::decrementLoading);
         });
     }

--- a/src/com/ss/editor/util/EditorStateManager.java
+++ b/src/com/ss/editor/util/EditorStateManager.java
@@ -1,0 +1,64 @@
+package com.ss.editor.util;
+
+/**
+ * Defines a current editor state.
+ *
+ * @author pavl_g.
+ */
+public class EditorStateManager {
+    public enum State {
+        SAVING("Saving"), UPDATING("Updating"),
+        EXITING("Exiting"), OPENING_FILE("Opening File");
+
+        private final String state;
+
+        State(final String state) {
+            this.state = state;
+        }
+
+        public String getState() {
+            return state;
+        }
+    }
+    private static State currentState = State.UPDATING;
+
+    private static void setCurrentState(final EditorStateManager.State currentState) {
+        EditorStateManager.currentState = currentState;
+    }
+
+    public static State getCurrentState() {
+        return currentState;
+    }
+
+    public static void setSaving() {
+        setCurrentState(State.SAVING);
+    }
+
+    public static boolean isSaving() {
+        return getCurrentState().getState().equals(State.SAVING.getState());
+    }
+
+    public static void setUpdating() {
+        setCurrentState(State.UPDATING);
+    }
+
+    public static boolean isUpdating() {
+        return getCurrentState().getState().equals(State.UPDATING.getState());
+    }
+
+    public static void setOpeningFile() {
+        setCurrentState(State.OPENING_FILE);
+    }
+
+    public static boolean isOpeningFile() {
+        return getCurrentState().getState().equals(State.OPENING_FILE.getState());
+    }
+
+    public static void setExiting() {
+        setCurrentState(State.EXITING);
+    }
+
+    public static boolean isExiting() {
+        return getCurrentState().getState().equals(State.EXITING.getState());
+    }
+}


### PR DESCRIPTION
## Fixed thread lock issue #3 when saving the terrain :
1) Removed stamp locker that was used to lock the scene update until editor tasks process.
2) Replaced the stamp with some Editor Flags using `EditorStateManager` and bound that to jme3 update : 
```java
    @Override
    public void update() {
        // finish if the editor state isn't for updating the scene
        if (!EditorStateManager.isUpdating()) {
            return;
        }
        // update the editor enqueued components before being hooked to jme3 update
        final GLTaskExecutor editorGLTaskExecutor = GLTaskExecutor.getInstance();
        editorGLTaskExecutor.dispatch();
        // hook up jme3 update --> calls --> simpleUpdate
        super.update();
        listener.setLocation(cam.getLocation());
        listener.setRotation(cam.getRotation());
    }
   ```
   Now the scene updater is well locked against editor tasks.